### PR TITLE
Use commit hash instead of version number

### DIFF
--- a/workflows/import.yml
+++ b/workflows/import.yml
@@ -53,7 +53,7 @@ jobs:
           git config --global user.name "GitHub Actions"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
       - name: 'Azure OIDC Login'
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID_OIDC }}
           tenant-id: ${{ vars.AZURE_TENANT_ID_OIDC }}


### PR DESCRIPTION
This PR updates import.yaml to use the commit hash for azure/login@v1 instead of the version number.

Fixes https://github.com/github/KustoSchemaToolsAction/security/code-scanning/5